### PR TITLE
原代码的模拟过程是不对的

### DIFF
--- a/AdvancedLevel_C++/1067. Sort with Swap(0,*) (25) .cpp
+++ b/AdvancedLevel_C++/1067. Sort with Swap(0,*) (25) .cpp
@@ -25,8 +25,9 @@ using namespace std;
 int main() {
     int n, cnt = 0, a[100010], id[100010];
     cin >> n;
+    int t;//t存储临时变量
     for(int i = 0; i < n; i++)
-        cin >> a[i];
+    {   cin >> t; a[t] = i; }
     for(int i = 1; i < n; i++) {
         if(i != a[i]) {
             while(a[0] != 0) {


### PR DESCRIPTION
比如按照源代码，示例的变化过程为：
{4, 0, 2, 1, 3}
Swap(4, 3) => {3, 0, 2, 1, 4}
Swap(3, 1) => {1, 0, 2, 3, 4}
Swap(1, 0) => {0, 1, 2, 3, 4}
当然了，柳神这个做法也是完全可以保证答案一致的，也可以证明（当0不在0位置时，每次交换都是一个包含0的并查集恢复的过程，交换的次数为并查集中元素的数目，如果改为我pull的形式，则含义与题意相同，每次均是0与其他元素交换，而柳神之前的代码的含义是最后再与0交换，交换的顺序不同不影响交换的次数）
更为本质的做法其实就是计算并查集的数目了，然后不需要模拟交换过程，注意分初始化时0是否在原位置两种情况即可。